### PR TITLE
Course requirement parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,12 +361,16 @@ name = "catalogue_scraper"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "colored",
  "env_logger",
  "expect-test",
  "html-escape",
  "log",
+ "once_cell",
  "rate_limit",
  "regex",
+ "rustemo",
+ "rustemo-compiler",
  "tl",
  "ureq",
  "url",
@@ -409,6 +424,45 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_derive",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -503,6 +557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "com"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +615,12 @@ checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
 name = "core-foundation"
@@ -1198,7 +1268,7 @@ checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
  "bitflags 2.4.2",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1232,6 +1302,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -1260,6 +1336,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1328,7 +1413,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "iced",
- "itertools",
+ "itertools 0.12.1",
  "num-traits",
  "once_cell",
  "time",
@@ -1524,12 +1609,22 @@ checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1558,6 +1653,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1664,6 +1768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84deb28a3a6c839ca42a7341664f32281416d69e2f29deb85aec5cc0243fdea8"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,7 +1850,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1863,7 +1973,7 @@ dependencies = [
  "bitflags 2.4.2",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.2.5",
  "log",
  "num-traits",
  "rustc-hash",
@@ -1925,7 +2035,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2056,6 +2166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
 name = "ouroboros"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,7 +2189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -2185,7 +2301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -2294,12 +2410,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2543,6 +2693,35 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustemo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82b4189b3d884e63add2c7f0bbc0c956af5fbd1f58a98c2a21e23c710788699"
+dependencies = [
+ "colored",
+ "petgraph",
+]
+
+[[package]]
+name = "rustemo-compiler"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dbc348195cd92cfadc9e04d88cdc9a6c78f4b849d5981524dafdc5ebad54e"
+dependencies = [
+ "clap",
+ "colored",
+ "convert_case",
+ "itertools 0.10.5",
+ "once_cell",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustemo",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "rustix"
@@ -2858,6 +3037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,6 +3114,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -3062,7 +3253,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -3581,7 +3772,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
- "indexmap",
+ "indexmap 2.2.5",
  "log",
  "naga",
  "once_cell",

--- a/catalogue_scraper/Cargo.toml
+++ b/catalogue_scraper/Cargo.toml
@@ -9,11 +9,16 @@ html-escape = "0.2.13"
 log = "0.4.21"
 rate_limit = "0.1.1"
 regex = "1.10.3"
+rustemo = "0.6.0"
 tl = "0.7.8"
 ureq = "2.9.6"
 url = "2.5.0"
 urlencoding = "2.1.3"
 write-json = "0.1.4"
+
+# Used by rustemo generated code
+colored = "2.1.0"
+once_cell = "1.19.0"
 
 [dependencies.env_logger]
 version = "0.11.2"
@@ -22,3 +27,6 @@ default-features = false
 
 [dev-dependencies]
 expect-test = "1.4.1"
+
+[build-dependencies]
+rustemo-compiler = "0.6.0"

--- a/catalogue_scraper/build.rs
+++ b/catalogue_scraper/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    rustemo_compiler::Settings::new()
+        .parser_algo(rustemo_compiler::ParserAlgo::GLR)
+        .actions_in_source_tree()
+        .partial_parse(false)
+        .process_dir()
+        .unwrap();
+}

--- a/catalogue_scraper/src/requirement_extractor.rs
+++ b/catalogue_scraper/src/requirement_extractor.rs
@@ -8,7 +8,7 @@ pub enum RequirementKind {
     Corequisite,
 }
 
-pub fn extract_requirements(s: &str) -> Vec<(RequirementKind, &str)> {
+pub fn extract_requirement_strings(s: &str) -> Vec<(RequirementKind, &str)> {
     const NO_PREREQUISITE_REGEX: &str = r"(?x)(?i)
         no \s (?<kind>pre-?requisite) ((\(s\)) | s)?
     ";
@@ -118,7 +118,7 @@ mod tests {
 
     #[track_caller]
     fn check_no_requirements(s: &str) {
-        let results = extract_requirements(s);
+        let results = extract_requirement_strings(s);
         assert_eq!(results, []);
     }
 
@@ -134,7 +134,7 @@ mod tests {
 
     #[track_caller]
     fn check_requirement(s: &str, requirement_kind: RequirementKind, output: Expect) {
-        let results = extract_requirements(s);
+        let results = extract_requirement_strings(s);
         let &[(result_kind, result_text)] = results.as_slice() else {
             panic!("Wanted one requirement: {results:?}, {s:?}")
         };
@@ -145,7 +145,7 @@ mod tests {
     #[track_caller]
     fn check_requirements(s: &str, output: Expect) {
         let mut out = String::new();
-        for (kind, text) in extract_requirements(s) {
+        for (kind, text) in extract_requirement_strings(s) {
             writeln!(&mut out, "{kind:?}: {text:?}").unwrap();
         }
         output.assert_eq(&out);

--- a/catalogue_scraper/src/requirements.rustemo
+++ b/catalogue_scraper/src/requirements.rustemo
@@ -1,8 +1,12 @@
-TopLevel: Any1 | TopLevelList | None;
+TopLevel: Any1 | TopLevelSemicolonList | TopLevelCommaList | None;
 
-TopLevelList: Any1 TopLevelListElement* TopLevelListLastElement?;
-TopLevelListElement: ',' Any1;
-TopLevelListLastElement: ',' AndEt Any1;
+TopLevelSemicolonList: Any1 TopLevelSemicolonListElement* TopLevelSemicolonListLastElement?;
+TopLevelSemicolonListElement: ';' Any1;
+TopLevelSemicolonListLastElement: ';' AndEt Any1;
+
+TopLevelCommaList: Any1 TopLevelCommaListElement* TopLevelCommaListLastElement?;
+TopLevelCommaListElement: ',' Any1;
+TopLevelCommaListLastElement: ',' AndEt Any1;
 
 Any1: AllCoursesSharedTopic
     | AllCourses
@@ -17,8 +21,11 @@ Any2: AnyCoursesSharedTopic
     | Any3;
 
 Any3: Course
+    | EitherCourse
+    | AnyCoursesSharedTopicNoCommas
     | CoursesSharedTopicSlashList
-    | Alternative;
+    | Alternative
+    | AMinimumGradeIn Any1;
 
 Any3Like: Any3
         | EnOrAlternativeOption;
@@ -38,6 +45,7 @@ CommaOptOr: CommaOrSemicolon? OrOu;
 
 AllCourses: Both? CommaSeparatedCourses2 CommaOptAnd Any2;
 AnyCourses: OneOf? CommaSeparatedCourses3 CommaOptOr Any3Like;
+EitherCourse: Either? Any3 OrOu Any3;
 
 CommaSeparatedCourses2: Any2 CommaSeparatedCoursesElement2*;
 CommaSeparatedCoursesElement2: CommaOrSemicolon Any2;
@@ -47,13 +55,16 @@ CommaSeparatedCoursesElement3: CommaOrSemicolon Any3;
 
 AllCoursesSharedTopic: Both? CoursesSharedTopicHead CommaOptAnd number=Number;
 AnyCoursesSharedTopic: OneOf? CoursesSharedTopicHead CommaOptOr number=Number
-                     | OneOf CoursesSharedTopicHead;
+                     | OneOf CoursesSharedTopicHead
+                     | OneOf? CoursesSharedTopicHead CommaOrSemicolon? OrAlternative;
 
 CoursesSharedTopicHead: topic=Topic number=Number CoursesSharedTopicHeadElement*;
 CoursesSharedTopicHeadElement: CommaOrSemicolon number=Number;
 
 CoursesSharedTopicSlashList: topic=Topic number=Number CoursesSharedTopicSlashListElement+;
 CoursesSharedTopicSlashListElement: Slash number=Number;
+
+AnyCoursesSharedTopicNoCommas: OneOf? CoursesSharedTopicHead;
 
 CommaOrSemicolon: ',' | ';';
 
@@ -65,8 +76,10 @@ Number: /\d+/;
 Topic: /(ZOOLE|ZOOL|WRS|WRITE|WKEXP|WGS|UNIV|UKR|THES|T DES|TAATC|TAARH|TAAMK|TAAMG|TAAFI|TAACO|SWED|SUST|SURG|STS|STATQ|STAT|SPRIT|SPH|SPAN|SOCIE|SOC|SLAV|SEM|SCSP|SCSOC|SC PO|SC INF|SCI|SCAND|SANSK|RUSS|R SOC|RSCH|RLS|REN R|RELIG|REHAB|RADTH|RADDI|PUNJ|PTHER|PSYCI|PSYCH|PSYCE|PSSTC|PORT|POLSH|POL S|PMCOL|PL SC|PLAN|PHYSQ|PHYSL|PHYSE|PHYS|PHILE|PHIL|PHARM|PGME|PGDE|PET E|PALEO|PAED|PAC|OPHTH|ONCOL|OM|OCCTH|OBIOL|OB GY|NUTR|NURS|NU FS|NS|NORW|NORSE|NEURO|NANO|MUSIQ|MUSIC|MST|M REG|MMI|MM|MLSCI|MLCS|MINT|MIN E|MICRE|MICRB|MGTSC|M EDU|MED|MEC E|MEAS|MDGEN|MATHQ|MATH|MAT E|MA SC|MARK|MA PH|MAFSJ|MACE|LITT|LIS|LINGQ|LING|LAW|LATIN|LA ST|LABMP|KSR|KRLS|KOREA|KIN|JAPAN|ITAL|IRISH|IPG|INT D|INFOR|IMINE|IMIN|HUME|HISTE|HIST|HINDI|HGEO|HE ED|HECOL|HEBR|HADVC|GTOTC|GSJ|GREEK|GERM|GEOPH|GENET|GENEQ|FS|FREN|FR ED|FRANC|FOREC|FOLK|F MED|FIN|EXT|EXSPH|EXSM|EXSDP|EXSCMA|EXRI|EXPH|EXOS|EXOPT|EXNS|EXMGT|EXLUP|EXLGP|EXLDR|EXIIC|EXIAPP|EXGL|EXGEN|EXFRM|EXERM|EXEN|EXELP|EXCST|EXCPE|EXCH|EXBA|EXASB|EXART|EXARE|EXALES|EXAGC|ET RE|ETIN|ETCAN|ESPA|EPE|ENV E|ENT|EN PH|ENG M|ENGL|ENGG|ENCS|ENCMP|EDU S|EDU P|EDU M|EDU F|EDU|EDSE|EDPY|EDPS|EDIT|EDHS|EDFX|EDES|EDEL|EDCT|ECONE|ECON|ECE|EASIA|EAS|EAP|E E|DRAMA|D HYG|DH|DEVDU|DES|DENT|DDS|DANCE|DAC|DA|CSL|CSD|COMM|CMPUT|CME|C LIT|CLASS|CIV E|CHRTP|CHRTC|CHINA|CHIM|CHEM|CH E|CELL|CEDUL|CCALS|CATS|BUS|BUEC|BTM|BOT|BME|B LAW|BIOPH|BIOLE|BIOL|BIOIN|BIOEN|BIOCM|BIOCH|AUSTA|AUSSC|AUSPA|AUSOC|AUSCI|AUSCA|AUREL|AUPSY|AUPOL|AUPHY|AUPHI|AUPED|AUPAC|AUMUS|AUMGT|AUMAT|AULAT|AULAN|AUIND|AUIDS|AUHUM|AUHIS|AUGER|AUGEO|AUGDS|AUFRE|AUFAR|AUEPS|AUENV|AUENG|AUEFX|AUEDC|AUECO|AUEAP|AUDRA|AUCSL|AUCSC|AUCRI|AUCLA|AUCHE|AUBIO|AUART|AUACC|ASTRO|ASL|ARTE|ART|AREC|ARAB|ANTHR|ANTHE|AN SC|ANGL|ANDR|ANATE|ANAT|ALS|ALES|AGRMT|AFNS|ADRAM|ADMI|ACCTG|ABROD)/;
 OneOf: /(?i)((one|any) of|un parmi):?/;
 Both: /(?i)both/;
+Either: /(?i)either/;
+AMinimumGradeIn: /(?i)a minimum grade of [A-Z][+-]? in/;
 Alternative: /(?i)(department(al)? consent|consent of( the)? (instructor|department( chair)?|faculty|program))/;
-EnOrAlternativeOption: /(?i)(equivalent|department(al)? consent|consent (of|from)( the)? (instructor|department( chair)?|faculty|program|course coordinators?))/;
+EnOrAlternativeOption: /(?i)(equivalent|department(al)? consent|consent (of|from)( the)? (instructor|department( chair)?|faculty|program|course coordinators?|college))/;
 EnUnlessAlternativeOption: /(?i)(waived by instructor)/;
 FrOrAlternativeOption: /(?i)(équivalent)/;
 Comma: ',';

--- a/catalogue_scraper/src/requirements.rustemo
+++ b/catalogue_scraper/src/requirements.rustemo
@@ -1,0 +1,81 @@
+TopLevel: Any1 | TopLevelList | None;
+
+TopLevelList: Any1 TopLevelListElement* TopLevelListLastElement?;
+TopLevelListElement: ',' Any1;
+TopLevelListLastElement: ',' AndEt Any1;
+
+Any1: AllCoursesSharedTopic
+    | AllCourses
+    | Any1 OrAlternative
+    | Any1 UnlessAlternative
+    | Any2;
+
+Any2: AnyCoursesSharedTopic
+    | AnyCourses
+    | Any2 OrAlternative
+    | Any2 UnlessAlternative
+    | Any3;
+
+Any3: Course
+    | CoursesSharedTopicSlashList
+    | Alternative;
+
+Any3Like: Any3
+        | EnOrAlternativeOption;
+
+OrAlternative: Or EnOrAlternativeOption
+             | Ou FrOrAlternativeOption;
+
+UnlessAlternative: Unless EnUnlessAlternativeOption;
+
+Course: topic=Topic number=Number;
+
+AndEt: And | Et | AndOr;
+OrOu: Or | Ou;
+
+CommaOptAnd: CommaOrSemicolon? AndEt;
+CommaOptOr: CommaOrSemicolon? OrOu;
+
+AllCourses: Both? CommaSeparatedCourses2 CommaOptAnd Any2;
+AnyCourses: OneOf? CommaSeparatedCourses3 CommaOptOr Any3Like;
+
+CommaSeparatedCourses2: Any2 CommaSeparatedCoursesElement2*;
+CommaSeparatedCoursesElement2: CommaOrSemicolon Any2;
+
+CommaSeparatedCourses3: Any3 CommaSeparatedCoursesElement3*;
+CommaSeparatedCoursesElement3: CommaOrSemicolon Any3;
+
+AllCoursesSharedTopic: Both? CoursesSharedTopicHead CommaOptAnd number=Number;
+AnyCoursesSharedTopic: OneOf? CoursesSharedTopicHead CommaOptOr number=Number
+                     | OneOf CoursesSharedTopicHead;
+
+CoursesSharedTopicHead: topic=Topic number=Number CoursesSharedTopicHeadElement*;
+CoursesSharedTopicHeadElement: CommaOrSemicolon number=Number;
+
+CoursesSharedTopicSlashList: topic=Topic number=Number CoursesSharedTopicSlashListElement+;
+CoursesSharedTopicSlashListElement: Slash number=Number;
+
+CommaOrSemicolon: ',' | ';';
+
+Layout: S;
+
+terminals
+S: /\s+/;
+Number: /\d+/;
+Topic: /(ZOOLE|ZOOL|WRS|WRITE|WKEXP|WGS|UNIV|UKR|THES|T DES|TAATC|TAARH|TAAMK|TAAMG|TAAFI|TAACO|SWED|SUST|SURG|STS|STATQ|STAT|SPRIT|SPH|SPAN|SOCIE|SOC|SLAV|SEM|SCSP|SCSOC|SC PO|SC INF|SCI|SCAND|SANSK|RUSS|R SOC|RSCH|RLS|REN R|RELIG|REHAB|RADTH|RADDI|PUNJ|PTHER|PSYCI|PSYCH|PSYCE|PSSTC|PORT|POLSH|POL S|PMCOL|PL SC|PLAN|PHYSQ|PHYSL|PHYSE|PHYS|PHILE|PHIL|PHARM|PGME|PGDE|PET E|PALEO|PAED|PAC|OPHTH|ONCOL|OM|OCCTH|OBIOL|OB GY|NUTR|NURS|NU FS|NS|NORW|NORSE|NEURO|NANO|MUSIQ|MUSIC|MST|M REG|MMI|MM|MLSCI|MLCS|MINT|MIN E|MICRE|MICRB|MGTSC|M EDU|MED|MEC E|MEAS|MDGEN|MATHQ|MATH|MAT E|MA SC|MARK|MA PH|MAFSJ|MACE|LITT|LIS|LINGQ|LING|LAW|LATIN|LA ST|LABMP|KSR|KRLS|KOREA|KIN|JAPAN|ITAL|IRISH|IPG|INT D|INFOR|IMINE|IMIN|HUME|HISTE|HIST|HINDI|HGEO|HE ED|HECOL|HEBR|HADVC|GTOTC|GSJ|GREEK|GERM|GEOPH|GENET|GENEQ|FS|FREN|FR ED|FRANC|FOREC|FOLK|F MED|FIN|EXT|EXSPH|EXSM|EXSDP|EXSCMA|EXRI|EXPH|EXOS|EXOPT|EXNS|EXMGT|EXLUP|EXLGP|EXLDR|EXIIC|EXIAPP|EXGL|EXGEN|EXFRM|EXERM|EXEN|EXELP|EXCST|EXCPE|EXCH|EXBA|EXASB|EXART|EXARE|EXALES|EXAGC|ET RE|ETIN|ETCAN|ESPA|EPE|ENV E|ENT|EN PH|ENG M|ENGL|ENGG|ENCS|ENCMP|EDU S|EDU P|EDU M|EDU F|EDU|EDSE|EDPY|EDPS|EDIT|EDHS|EDFX|EDES|EDEL|EDCT|ECONE|ECON|ECE|EASIA|EAS|EAP|E E|DRAMA|D HYG|DH|DEVDU|DES|DENT|DDS|DANCE|DAC|DA|CSL|CSD|COMM|CMPUT|CME|C LIT|CLASS|CIV E|CHRTP|CHRTC|CHINA|CHIM|CHEM|CH E|CELL|CEDUL|CCALS|CATS|BUS|BUEC|BTM|BOT|BME|B LAW|BIOPH|BIOLE|BIOL|BIOIN|BIOEN|BIOCM|BIOCH|AUSTA|AUSSC|AUSPA|AUSOC|AUSCI|AUSCA|AUREL|AUPSY|AUPOL|AUPHY|AUPHI|AUPED|AUPAC|AUMUS|AUMGT|AUMAT|AULAT|AULAN|AUIND|AUIDS|AUHUM|AUHIS|AUGER|AUGEO|AUGDS|AUFRE|AUFAR|AUEPS|AUENV|AUENG|AUEFX|AUEDC|AUECO|AUEAP|AUDRA|AUCSL|AUCSC|AUCRI|AUCLA|AUCHE|AUBIO|AUART|AUACC|ASTRO|ASL|ARTE|ART|AREC|ARAB|ANTHR|ANTHE|AN SC|ANGL|ANDR|ANATE|ANAT|ALS|ALES|AGRMT|AFNS|ADRAM|ADMI|ACCTG|ABROD)/;
+OneOf: /(?i)((one|any) of|un parmi):?/;
+Both: /(?i)both/;
+Alternative: /(?i)(department(al)? consent|consent of( the)? (instructor|department( chair)?|faculty|program))/;
+EnOrAlternativeOption: /(?i)(equivalent|department(al)? consent|consent (of|from)( the)? (instructor|department( chair)?|faculty|program|course coordinators?))/;
+EnUnlessAlternativeOption: /(?i)(waived by instructor)/;
+FrOrAlternativeOption: /(?i)(équivalent)/;
+Comma: ',';
+Semicolon: ';';
+Slash: '/';
+AndOr: /(?i)and\/or/;
+And: /(?i)and/;
+Et: /(?i)et/;
+Or: /(?i)or/;
+Ou: /(?i)ou/;
+None: /(?i)(none|variable|var(y|ies) according to topic|are determined by the instructor in the course outline)/;
+Unless: /(?i)unless/;

--- a/catalogue_scraper/src/requirements_actions.rs
+++ b/catalogue_scraper/src/requirements_actions.rs
@@ -94,6 +94,7 @@ pub struct Course {
 pub type AllCourses = Expr;
 pub type AllCoursesSharedTopic = Expr;
 pub type Alternative = ();
+pub type AMinimumGradeIn = ();
 pub type And = ();
 pub type AndEt = ();
 pub type AndOr = ();
@@ -103,6 +104,7 @@ pub type Any3 = Expr;
 pub type Any3Like = Expr;
 pub type AnyCourses = Expr;
 pub type AnyCoursesSharedTopic = Expr;
+pub type AnyCoursesSharedTopicNoCommas = Expr;
 pub type Both = ();
 pub type BothOpt = ();
 pub type CommaOptAnd = ();
@@ -124,6 +126,9 @@ pub type CoursesSharedTopicHeadElement1 = Vec<u64>;
 pub type CoursesSharedTopicSlashList = Expr;
 pub type CoursesSharedTopicSlashListElement = u64;
 pub type CoursesSharedTopicSlashListElement1 = Vec<u64>;
+pub type Either = ();
+pub type EitherCourse = Expr;
+pub type EitherOpt = ();
 pub type EnOrAlternativeOption = ();
 pub type EnUnlessAlternativeOption = ();
 pub type Et = ();
@@ -138,12 +143,20 @@ pub type OrOu = ();
 pub type Ou = ();
 pub type Topic = String;
 pub type TopLevel = Expr;
+pub type TopLevelCommaList = TopLevelList;
+pub type TopLevelCommaListElement = Any1;
+pub type TopLevelCommaListElement0 = TopLevelCommaListElement1;
+pub type TopLevelCommaListElement1 = Vec<TopLevelCommaListElement>;
+pub type TopLevelCommaListLastElement = TopLevelListLastElement;
+pub type TopLevelCommaListLastElementOpt = TopLevelCommaListLastElement;
 pub type TopLevelList = Expr;
-pub type TopLevelListElement = Expr;
-pub type TopLevelListElement0 = Vec<Expr>;
-pub type TopLevelListElement1 = Vec<Expr>;
 pub type TopLevelListLastElement = Expr;
-pub type TopLevelListLastElementOpt = Expr;
+pub type TopLevelSemicolonList = TopLevelCommaList;
+pub type TopLevelSemicolonListElement = Any1;
+pub type TopLevelSemicolonListElement0 = TopLevelSemicolonListElement1;
+pub type TopLevelSemicolonListElement1 = Vec<TopLevelSemicolonListElement>;
+pub type TopLevelSemicolonListLastElement = TopLevelListLastElement;
+pub type TopLevelSemicolonListLastElementOpt = TopLevelSemicolonListLastElement;
 pub type Unless = ();
 pub type UnlessAlternative = ();
 /// Functions are sorted alphabetically
@@ -186,6 +199,7 @@ pub fn all_courses_shared_topic_c1(
     )
 }
 pub fn alternative(_: &Ctx, _: Token) {}
+pub fn aminimum_grade_in(_: &Ctx, _: Token) {}
 pub fn and_et_and_or(_: &Ctx, (): ()) {}
 pub fn and_et_and(_: &Ctx, (): ()) {}
 pub fn and_et_et(_: &Ctx, (): ()) {}
@@ -222,6 +236,22 @@ pub fn any_courses_shared_topic_c2(
             .collect(),
     )
 }
+pub fn any_courses_shared_topic_c3(
+    ctx: &Ctx,
+    (): (),
+    (topic, numbers): (Topic, Vec<Number>),
+    (): (),
+    (): (),
+) -> Expr {
+    any_courses_shared_topic_c2(ctx, (), (topic, numbers))
+}
+pub fn any_courses_shared_topic_no_commas_c1(
+    ctx: &Ctx,
+    (): (),
+    (topic, numbers): (Topic, Vec<Number>),
+) -> Expr {
+    any_courses_shared_topic_c2(ctx, (), (topic, numbers))
+}
 pub fn any1_all_courses_shared_topic(_: &Ctx, expr: Expr) -> Expr {
     expr
 }
@@ -255,10 +285,22 @@ pub fn any2_c4(_: &Ctx, expr: Expr, (): ()) -> Expr {
 pub fn any3_alternative(_: &Ctx, (): ()) -> Expr {
     Expr::Empty
 }
+pub fn any3_any_courses_shared_topic_no_commas(
+    _: &Ctx,
+    expr: AnyCoursesSharedTopicNoCommas,
+) -> Expr {
+    expr
+}
+pub fn any3_c6(_: &Ctx, (): (), expr: Expr) -> Expr {
+    expr
+}
 pub fn any3_course(_: &Ctx, course: Course) -> Expr {
     Expr::Course(course)
 }
 pub fn any3_courses_shared_topic_slash_list(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any3_either_course(_: &Ctx, expr: Expr) -> Expr {
     expr
 }
 pub fn any3like_any3(_: &Ctx, expr: Expr) -> Expr {
@@ -418,6 +460,12 @@ pub fn courses_shared_topic_slash_list_element1_courses_shared_topic_slash_list_
 ) -> Vec<u64> {
     vec![num]
 }
+pub fn either_course_c1(_: &Ctx, (): (), lhs: Any3, (): (), rhs: Any3) -> Expr {
+    Expr::any(vec![lhs, rhs])
+}
+pub fn either_opt_either(_: &Ctx, (): ()) {}
+pub fn either_opt_empty(_: &Ctx) {}
+pub fn either(_: &Ctx, _: Token) {}
 pub fn en_or_alternative_option(_: &Ctx, _: Token) {}
 pub fn en_unless_alternative_option(_: &Ctx, _: Token) {}
 pub fn et(_: &Ctx, _: Token) {}
@@ -438,7 +486,7 @@ pub fn ou(_: &Ctx, _: Token) {}
 pub fn top_level_any1(_: &Ctx, expr: Expr) -> Expr {
     expr
 }
-pub fn top_level_list_c1(
+pub fn top_level_comma_list_c1(
     _: &Ctx,
     before: Expr,
     mut list: Vec<Expr>,
@@ -448,19 +496,19 @@ pub fn top_level_list_c1(
     list.push(after);
     Expr::all(list)
 }
-pub fn top_level_list_element_any1(_: &Ctx, expr: Expr) -> Expr {
+pub fn top_level_comma_list_element_any1(_: &Ctx, expr: Expr) -> Expr {
     expr
 }
-pub fn top_level_list_element0_empty(_: &Ctx) -> Vec<Expr> {
+pub fn top_level_comma_list_element0_empty(_: &Ctx) -> Vec<Expr> {
     vec![]
 }
-pub fn top_level_list_element0_top_level_list_element1(
+pub fn top_level_comma_list_element0_top_level_comma_list_element1(
     _: &Ctx,
-    list: Vec<Expr>,
-) -> Vec<Expr> {
-    list
+    top_level_comma_list_element1: TopLevelCommaListElement1,
+) -> TopLevelCommaListElement0 {
+    top_level_comma_list_element1
 }
-pub fn top_level_list_element1_c1(
+pub fn top_level_comma_list_element1_c1(
     _: &Ctx,
     mut list: Vec<Expr>,
     expr: Expr,
@@ -468,29 +516,86 @@ pub fn top_level_list_element1_c1(
     list.push(expr);
     list
 }
-pub fn top_level_list_element1_top_level_list_element(
+pub fn top_level_comma_list_element1_top_level_comma_list_element(
     _: &Ctx,
-    top_level_list_element: Expr,
-) -> Vec<Expr> {
-    vec![top_level_list_element]
+    top_level_comma_list_element: TopLevelCommaListElement,
+) -> TopLevelCommaListElement1 {
+    vec![top_level_comma_list_element]
 }
-pub fn top_level_list_last_element_c1(_: &Ctx, (): (), expr: Expr) -> Expr {
+pub fn top_level_comma_list_last_element_c1(_: &Ctx, (): (), expr: Expr) -> Expr {
     expr
 }
-pub fn top_level_list_last_element_opt_empty(_: &Ctx) -> Expr {
+pub fn top_level_comma_list_last_element_opt_empty(_: &Ctx) -> Expr {
     Expr::Empty
 }
-pub fn top_level_list_last_element_opt_top_level_list_last_element(
+pub fn top_level_comma_list_last_element_opt_top_level_comma_list_last_element(
     _: &Ctx,
-    top_level_list_last_element: Expr,
-) -> Expr {
-    top_level_list_last_element
+    top_level_comma_list_last_element: TopLevelCommaListLastElement,
+) -> TopLevelCommaListLastElementOpt {
+    top_level_comma_list_last_element
 }
 pub fn top_level_none(_: &Ctx, (): ()) -> Expr {
     Expr::Empty
 }
-pub fn top_level_top_level_list(_: &Ctx, expr: Expr) -> Expr {
+pub fn top_level_semicolon_list_c1(
+    _: &Ctx,
+    before: Expr,
+    mut list: Vec<Expr>,
+    after: Expr,
+) -> Expr {
+    list.insert(0, before);
+    list.push(after);
+    Expr::all(list)
+}
+pub fn top_level_semicolon_list_element_any1(_: &Ctx, expr: Expr) -> Expr {
     expr
+}
+pub fn top_level_semicolon_list_element0_empty(_: &Ctx) -> Vec<Expr> {
+    vec![]
+}
+pub fn top_level_semicolon_list_element0_top_level_semicolon_list_element1(
+    _: &Ctx,
+    top_level_semicolon_list_element1: TopLevelSemicolonListElement1,
+) -> TopLevelSemicolonListElement0 {
+    top_level_semicolon_list_element1
+}
+pub fn top_level_semicolon_list_element1_c1(
+    _: &Ctx,
+    mut list: Vec<Expr>,
+    expr: Expr,
+) -> Vec<Expr> {
+    list.push(expr);
+    list
+}
+pub fn top_level_semicolon_list_element1_top_level_semicolon_list_element(
+    _: &Ctx,
+    top_level_semicolon_list_element: TopLevelSemicolonListElement,
+) -> TopLevelSemicolonListElement1 {
+    vec![top_level_semicolon_list_element]
+}
+pub fn top_level_semicolon_list_last_element_c1(_: &Ctx, (): (), expr: Expr) -> Expr {
+    expr
+}
+pub fn top_level_semicolon_list_last_element_opt_empty(_: &Ctx) -> Expr {
+    Expr::Empty
+}
+pub fn top_level_semicolon_list_last_element_opt_top_level_semicolon_list_last_element(
+    _: &Ctx,
+    top_level_semicolon_list_last_element: TopLevelSemicolonListLastElement,
+) -> TopLevelSemicolonListLastElementOpt {
+    top_level_semicolon_list_last_element
+}
+pub fn top_level_top_level_comma_list(
+    _: &Ctx,
+    top_level_comma_list: TopLevelCommaList,
+) -> TopLevel {
+    top_level_comma_list
+}
+pub fn top_level_top_level_semicolon_list(
+    _: &Ctx,
+    top_level_semicolon_list: TopLevelSemicolonList,
+) -> TopLevel {
+    top_level_semicolon_list
 }
 pub fn topic(_: &Ctx, token: Token) -> String {
     token.value.into()

--- a/catalogue_scraper/src/requirements_actions.rs
+++ b/catalogue_scraper/src/requirements_actions.rs
@@ -1,0 +1,499 @@
+use super::requirements::{Context, TokenKind};
+/// This file is maintained by rustemo but can be modified manually.
+/// All manual changes will be preserved except non-doc comments.
+use rustemo::Token as RustemoToken;
+use std::fmt::Write as _;
+pub type Ctx<'i> = Context<'i, str>;
+pub type Token<'i> = RustemoToken<'i, str, TokenKind>;
+#[derive(Clone, PartialEq, Eq)]
+pub enum Expr {
+    All(Vec<Expr>),
+    Any(Vec<Expr>),
+    Course(Course),
+    Empty,
+}
+impl Expr {
+    pub fn to_json(&self, mut obj: write_json::Object<'_>) {
+        match self {
+            Expr::All(args) => {
+                let mut arr = obj.array("all");
+                args.into_iter().for_each(|arg| arg.to_json(arr.object()));
+            }
+            Expr::Any(args) => {
+                let mut arr = obj.array("any");
+                args.into_iter().for_each(|arg| arg.to_json(arr.object()));
+            }
+            Expr::Course(Course { topic, number }) => {
+                obj.object("course")
+                    .string("topic", topic)
+                    .string("number", &number.to_string());
+            }
+            Expr::Empty => {}
+        };
+    }
+}
+impl Expr {
+    pub fn all(mut list: Vec<Expr>) -> Expr {
+        list.retain(|expr| expr != &Expr::Empty);
+        if list.is_empty() {
+            Expr::Empty
+        } else if list.len() == 1 {
+            list.into_iter().nth(0).unwrap()
+        } else {
+            Expr::All(list)
+        }
+    }
+    pub fn any(mut list: Vec<Expr>) -> Expr {
+        list.retain(|expr| expr != &Expr::Empty);
+        if list.is_empty() {
+            Expr::Empty
+        } else if list.len() == 1 {
+            list.into_iter().nth(0).unwrap()
+        } else {
+            Expr::Any(list)
+        }
+    }
+}
+impl std::fmt::Debug for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Expr::Any(args) => {
+                write!(f, "(any")?;
+                for arg in args {
+                    write!(f, " {arg:?}")?;
+                }
+                f.write_char(')')?;
+                Ok(())
+            }
+            Expr::All(args) => {
+                write!(f, "(all")?;
+                for arg in args {
+                    write!(f, " {arg:?}")?;
+                }
+                f.write_char(')')?;
+                Ok(())
+            }
+            Expr::Course(arg0) => write!(f, "({} {})", arg0.topic, arg0.number),
+            Expr::Empty => write!(f, "()"),
+        }
+    }
+}
+impl From<Option<Expr>> for Expr {
+    fn from(value: Option<Expr>) -> Expr {
+        match value {
+            Some(expr) => expr,
+            None => Expr::Empty,
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Course {
+    pub topic: String,
+    pub number: u64,
+}
+pub type AllCourses = Expr;
+pub type AllCoursesSharedTopic = Expr;
+pub type Alternative = ();
+pub type And = ();
+pub type AndEt = ();
+pub type AndOr = ();
+pub type Any1 = Expr;
+pub type Any2 = Expr;
+pub type Any3 = Expr;
+pub type Any3Like = Expr;
+pub type AnyCourses = Expr;
+pub type AnyCoursesSharedTopic = Expr;
+pub type Both = ();
+pub type BothOpt = ();
+pub type CommaOptAnd = ();
+pub type CommaOptOr = ();
+pub type CommaOrSemicolon = ();
+pub type CommaOrSemicolonOpt = ();
+pub type CommaSeparatedCourses2 = Vec<Expr>;
+pub type CommaSeparatedCourses3 = Vec<Expr>;
+pub type CommaSeparatedCoursesElement2 = Expr;
+pub type CommaSeparatedCoursesElement20 = Vec<Expr>;
+pub type CommaSeparatedCoursesElement21 = Vec<Expr>;
+pub type CommaSeparatedCoursesElement3 = Expr;
+pub type CommaSeparatedCoursesElement30 = Vec<Expr>;
+pub type CommaSeparatedCoursesElement31 = Vec<Expr>;
+pub type CoursesSharedTopicHead = (Topic, Vec<Number>);
+pub type CoursesSharedTopicHeadElement = u64;
+pub type CoursesSharedTopicHeadElement0 = Vec<u64>;
+pub type CoursesSharedTopicHeadElement1 = Vec<u64>;
+pub type CoursesSharedTopicSlashList = Expr;
+pub type CoursesSharedTopicSlashListElement = u64;
+pub type CoursesSharedTopicSlashListElement1 = Vec<u64>;
+pub type EnOrAlternativeOption = ();
+pub type EnUnlessAlternativeOption = ();
+pub type Et = ();
+pub type FrOrAlternativeOption = ();
+pub type None = ();
+pub type Number = u64;
+pub type OneOf = ();
+pub type OneOfOpt = ();
+pub type Or = ();
+pub type OrAlternative = ();
+pub type OrOu = ();
+pub type Ou = ();
+pub type Topic = String;
+pub type TopLevel = Expr;
+pub type TopLevelList = Expr;
+pub type TopLevelListElement = Expr;
+pub type TopLevelListElement0 = Vec<Expr>;
+pub type TopLevelListElement1 = Vec<Expr>;
+pub type TopLevelListLastElement = Expr;
+pub type TopLevelListLastElementOpt = Expr;
+pub type Unless = ();
+pub type UnlessAlternative = ();
+/// Functions are sorted alphabetically
+/// To re-sort it in VSCode:
+/// - Select "pub-fn" (written with a dash here so it's not selected)
+/// - Hit ctrl-alt-l to select all instances
+/// - Hit ctrl-shift-p then "Expand selection"
+/// - Hit ctrl-shift-p then "rust-analyzer: Join lines" (twice if necessary)
+/// - Select all the lines with functions
+/// - Hit ctrl-shift-p then "Sort lines ascending"
+const _: () = ();
+pub fn all_courses_c1(
+    _: &Ctx,
+    (): (),
+    mut list: Vec<Expr>,
+    (): (),
+    expr: Expr,
+) -> AllCourses {
+    list.push(expr);
+    Expr::all(list)
+}
+pub fn all_courses_shared_topic_c1(
+    _: &Ctx,
+    (): (),
+    (topic, mut numbers): (String, Vec<u64>),
+    (): (),
+    number: u64,
+) -> Expr {
+    numbers.push(number);
+    Expr::all(
+        numbers
+            .into_iter()
+            .map(|number| {
+                Expr::Course(Course {
+                    topic: topic.clone(),
+                    number,
+                })
+            })
+            .collect(),
+    )
+}
+pub fn alternative(_: &Ctx, _: Token) {}
+pub fn and_et_and_or(_: &Ctx, (): ()) {}
+pub fn and_et_and(_: &Ctx, (): ()) {}
+pub fn and_et_et(_: &Ctx, (): ()) {}
+pub fn and_or(_: &Ctx, _: Token) {}
+pub fn and(_: &Ctx, _: Token) {}
+pub fn any_courses_c1(_: &Ctx, (): (), mut list: Vec<Expr>, (): (), expr: Expr) -> Expr {
+    list.push(expr);
+    Expr::any(list)
+}
+pub fn any_courses_shared_topic_c1(
+    ctx: &Ctx,
+    (): (),
+    (topic, mut numbers): (String, Vec<u64>),
+    (): (),
+    number: u64,
+) -> Expr {
+    numbers.push(number);
+    any_courses_shared_topic_c2(ctx, (), (topic, numbers))
+}
+pub fn any_courses_shared_topic_c2(
+    _: &Ctx,
+    (): (),
+    (topic, nums): (String, Vec<u64>),
+) -> Expr {
+    Expr::any(
+        nums
+            .into_iter()
+            .map(|number| {
+                Expr::Course(Course {
+                    topic: topic.clone(),
+                    number,
+                })
+            })
+            .collect(),
+    )
+}
+pub fn any1_all_courses_shared_topic(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any1_all_courses(_: &Ctx, expr: AllCourses) -> Expr {
+    expr
+}
+pub fn any1_any2(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any1_c3(_: &Ctx, expr: Expr, (): ()) -> Expr {
+    expr
+}
+pub fn any1_c4(_: &Ctx, expr: Expr, (): ()) -> Expr {
+    expr
+}
+pub fn any2_any_courses_shared_topic(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any2_any_courses(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any2_any3(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any2_c3(_: &Ctx, expr: Expr, (): ()) -> Expr {
+    expr
+}
+pub fn any2_c4(_: &Ctx, expr: Expr, (): ()) -> Expr {
+    expr
+}
+pub fn any3_alternative(_: &Ctx, (): ()) -> Expr {
+    Expr::Empty
+}
+pub fn any3_course(_: &Ctx, course: Course) -> Expr {
+    Expr::Course(course)
+}
+pub fn any3_courses_shared_topic_slash_list(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any3like_any3(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn any3like_en_or_alternative_option(_: &Ctx, (): ()) -> Expr {
+    Expr::Empty
+}
+pub fn both_opt_both(_: &Ctx, (): Both) {}
+pub fn both_opt_empty(_: &Ctx) {}
+pub fn both(_: &Ctx, _: Token) {}
+pub fn comma_opt_and_c1(_: &Ctx, (): (), (): ()) {}
+pub fn comma_opt_or_c1(_: &Ctx, (): (), (): ()) {}
+pub fn comma_or_semicolon_comma(_: &Ctx) {}
+pub fn comma_or_semicolon_opt_comma_or_semicolon(_: &Ctx, (): ()) {}
+pub fn comma_or_semicolon_opt_empty(_: &Ctx) {}
+pub fn comma_or_semicolon_semicolon(_: &Ctx) {}
+pub fn comma_separated_courses_element2_c1(_: &Ctx, (): (), expr: Expr) -> Expr {
+    expr
+}
+pub fn comma_separated_courses_element20_comma_separated_courses_element21(
+    _: &Ctx,
+    list: Vec<Expr>,
+) -> Vec<Expr> {
+    list
+}
+pub fn comma_separated_courses_element20_empty(_: &Ctx) -> Vec<Expr> {
+    vec![]
+}
+pub fn comma_separated_courses_element21_c1(
+    _: &Ctx,
+    mut list: Vec<Expr>,
+    expr: Expr,
+) -> Vec<Expr> {
+    list.push(expr);
+    list
+}
+pub fn comma_separated_courses_element21_comma_separated_courses_element2(
+    _: &Ctx,
+    expr: Expr,
+) -> Vec<Expr> {
+    vec![expr]
+}
+pub fn comma_separated_courses_element3_c1(_: &Ctx, (): (), expr: Expr) -> Expr {
+    expr
+}
+pub fn comma_separated_courses_element30_comma_separated_courses_element31(
+    _: &Ctx,
+    list: Vec<Expr>,
+) -> Vec<Expr> {
+    list
+}
+pub fn comma_separated_courses_element30_empty(_: &Ctx) -> Vec<Expr> {
+    vec![]
+}
+pub fn comma_separated_courses_element31_c1(
+    _: &Ctx,
+    mut list: Vec<Expr>,
+    expr: Expr,
+) -> Vec<Expr> {
+    list.push(expr);
+    list
+}
+pub fn comma_separated_courses_element31_comma_separated_courses_element3(
+    _: &Ctx,
+    list: Expr,
+) -> Vec<Expr> {
+    vec![list]
+}
+pub fn comma_separated_courses2_c1(
+    _: &Ctx,
+    expr: Expr,
+    mut list: Vec<Expr>,
+) -> Vec<Expr> {
+    list.insert(0, expr);
+    list
+}
+pub fn comma_separated_courses3_c1(
+    _: &Ctx,
+    expr: Expr,
+    mut list: Vec<Expr>,
+) -> Vec<Expr> {
+    list.insert(0, expr);
+    list
+}
+pub fn course_c1(_: &Ctx, topic: String, number: u64) -> Course {
+    Course { topic, number }
+}
+pub fn courses_shared_topic_head_c1(
+    _: &Ctx,
+    topic: String,
+    num: u64,
+    mut nums: Vec<u64>,
+) -> (String, Vec<u64>) {
+    nums.insert(0, num);
+    (topic, nums)
+}
+pub fn courses_shared_topic_head_element_c1(_: &Ctx, (): (), num: u64) -> u64 {
+    num
+}
+pub fn courses_shared_topic_head_element0_courses_shared_topic_head_element1(
+    _: &Ctx,
+    list: Vec<u64>,
+) -> Vec<u64> {
+    list
+}
+pub fn courses_shared_topic_head_element0_empty(_: &Ctx) -> Vec<u64> {
+    vec![]
+}
+pub fn courses_shared_topic_head_element1_c1(
+    _: &Ctx,
+    mut list: Vec<u64>,
+    num: u64,
+) -> Vec<u64> {
+    list.push(num);
+    list
+}
+pub fn courses_shared_topic_head_element1_courses_shared_topic_head_element(
+    _: &Ctx,
+    num: u64,
+) -> Vec<u64> {
+    vec![num]
+}
+pub fn courses_shared_topic_slash_list_c1(
+    _: &Ctx,
+    topic: String,
+    num: u64,
+    mut nums: Vec<u64>,
+) -> Expr {
+    nums.insert(0, num);
+    Expr::any(
+        nums
+            .into_iter()
+            .map(|number| {
+                Expr::Course(Course {
+                    topic: topic.clone(),
+                    number,
+                })
+            })
+            .collect(),
+    )
+}
+pub fn courses_shared_topic_slash_list_element_c1(_: &Ctx, num: Number) -> u64 {
+    num
+}
+pub fn courses_shared_topic_slash_list_element1_c1(
+    _: &Ctx,
+    mut list: Vec<u64>,
+    num: u64,
+) -> Vec<u64> {
+    list.push(num);
+    list
+}
+pub fn courses_shared_topic_slash_list_element1_courses_shared_topic_slash_list_element(
+    _: &Ctx,
+    num: u64,
+) -> Vec<u64> {
+    vec![num]
+}
+pub fn en_or_alternative_option(_: &Ctx, _: Token) {}
+pub fn en_unless_alternative_option(_: &Ctx, _: Token) {}
+pub fn et(_: &Ctx, _: Token) {}
+pub fn fr_or_alternative_option(_: &Ctx, _: Token) {}
+pub fn none(_: &Ctx, _: Token) {}
+pub fn number(_: &Ctx, token: Token) -> u64 {
+    token.value.parse().unwrap()
+}
+pub fn one_of_opt_empty(_: &Ctx) {}
+pub fn one_of_opt_one_of(_: &Ctx, (): ()) {}
+pub fn one_of(_: &Ctx, _: Token) {}
+pub fn or_alternative_c1(_: &Ctx, (): (), (): ()) {}
+pub fn or_alternative_c2(_: &Ctx, (): (), (): ()) {}
+pub fn or_ou_or(_: &Ctx, (): ()) {}
+pub fn or_ou_ou(_: &Ctx, (): ()) {}
+pub fn or(_: &Ctx, _: Token) {}
+pub fn ou(_: &Ctx, _: Token) {}
+pub fn top_level_any1(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn top_level_list_c1(
+    _: &Ctx,
+    before: Expr,
+    mut list: Vec<Expr>,
+    after: Expr,
+) -> Expr {
+    list.insert(0, before);
+    list.push(after);
+    Expr::all(list)
+}
+pub fn top_level_list_element_any1(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn top_level_list_element0_empty(_: &Ctx) -> Vec<Expr> {
+    vec![]
+}
+pub fn top_level_list_element0_top_level_list_element1(
+    _: &Ctx,
+    list: Vec<Expr>,
+) -> Vec<Expr> {
+    list
+}
+pub fn top_level_list_element1_c1(
+    _: &Ctx,
+    mut list: Vec<Expr>,
+    expr: Expr,
+) -> Vec<Expr> {
+    list.push(expr);
+    list
+}
+pub fn top_level_list_element1_top_level_list_element(
+    _: &Ctx,
+    top_level_list_element: Expr,
+) -> Vec<Expr> {
+    vec![top_level_list_element]
+}
+pub fn top_level_list_last_element_c1(_: &Ctx, (): (), expr: Expr) -> Expr {
+    expr
+}
+pub fn top_level_list_last_element_opt_empty(_: &Ctx) -> Expr {
+    Expr::Empty
+}
+pub fn top_level_list_last_element_opt_top_level_list_last_element(
+    _: &Ctx,
+    top_level_list_last_element: Expr,
+) -> Expr {
+    top_level_list_last_element
+}
+pub fn top_level_none(_: &Ctx, (): ()) -> Expr {
+    Expr::Empty
+}
+pub fn top_level_top_level_list(_: &Ctx, expr: Expr) -> Expr {
+    expr
+}
+pub fn topic(_: &Ctx, token: Token) -> String {
+    token.value.into()
+}
+pub fn unless_alternative_c1(_: &Ctx, (): (), (): ()) {}
+pub fn unless(_: &Ctx, _: Token) {}

--- a/catalogue_scraper/src/requirements_tests.rs
+++ b/catalogue_scraper/src/requirements_tests.rs
@@ -1,0 +1,617 @@
+use crate::requirements;
+use crate::requirements_actions::Expr;
+use expect_test::{expect, Expect};
+use rustemo::Parser as _;
+
+#[track_caller]
+fn parse_requirement(s: &str) -> Result<Expr, String> {
+    let parser = requirements::RequirementsParser::new();
+    match parser.parse(s) {
+        Ok(forest) => forest
+            .get_first_tree()
+            .map(|tree| {
+                let mut builder = requirements::DefaultBuilder::new();
+                let expr = tree.build(&mut builder);
+                expr
+            })
+            .ok_or_else(|| "no tree".to_owned()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[track_caller]
+fn check(input: &str, output: Expect) {
+    let res = parse_requirement(input);
+    match res {
+        Ok(req) => {
+            output.assert_eq(&format!("{req:#?}"));
+        }
+        Err(e) => {
+            output.assert_eq(&format!("Error: {e}"));
+        }
+    }
+}
+
+#[test]
+fn parse_simple_course_requirement() {
+    check("CMPUT 174", expect!["(CMPUT 174)"]);
+}
+
+#[test]
+fn parse_any_of_course_requirements() {
+    check(
+        "CMPUT 174 or CMPUT 274",
+        expect!["(any (CMPUT 174) (CMPUT 274))"],
+    );
+    check(
+        "CMPUT 174, CMPUT 274, CMPUT 175 or CMPUT 275",
+        expect!["(any (CMPUT 174) (CMPUT 274) (CMPUT 175) (CMPUT 275))"],
+    );
+}
+
+#[test]
+fn parse_any_of_course_requirements_with_prefix() {
+    check(
+        "one of CMPUT 175 or 275",
+        expect!["(any (CMPUT 175) (CMPUT 275))"],
+    );
+    check(
+        "one of CMPUT 175 or CMPUT 275",
+        expect!["(any (CMPUT 175) (CMPUT 275))"],
+    );
+    check(
+        "any of CMPUT 175 or CMPUT 275",
+        expect!["(any (CMPUT 175) (CMPUT 275))"],
+    );
+}
+
+#[test]
+fn parse_any_of_course_requirements_without_repeated_topic() {
+    check("CMPUT 174 or 274", expect!["(any (CMPUT 174) (CMPUT 274))"]);
+}
+
+#[test]
+fn parse_all_of_course_requirements() {
+    check(
+        "ECON 101 and ECON 102",
+        expect!["(all (ECON 101) (ECON 102))"],
+    );
+}
+
+#[test]
+fn parse_all_of_course_requirements_without_repeated_topic() {
+    check("ECON 101 and 102", expect!["(all (ECON 101) (ECON 102))"]);
+}
+
+#[test]
+fn parse_top_level_comma_separated_list() {
+    check("ACCTG 614, FIN 501", expect!["(all (ACCTG 614) (FIN 501))"]);
+    check(
+        "ACCTG 614, ACCTG 610, FIN 501",
+        expect!["(all (ACCTG 614) (ACCTG 610) (FIN 501))"],
+    );
+    check(
+        "ACCTG 614 or 610, FIN 501 or 503",
+        expect!["(all (any (ACCTG 614) (ACCTG 610)) (any (FIN 501) (FIN 503)))"],
+    );
+}
+
+#[test]
+fn misc_working() {
+    check(
+        "ECON 109 and MATH 156",
+        expect!["(all (ECON 109) (MATH 156))"],
+    );
+    check(
+        "ECON 109, and MATH 156",
+        expect!["(all (ECON 109) (MATH 156))"],
+    );
+    check(
+        "ECON 109, ECON 110 and MATH 156",
+        expect!["(all (ECON 109) (ECON 110) (MATH 156))"],
+    );
+    check(
+        "ECON 109, ECON 110, and MATH 156",
+        expect!["(all (ECON 109) (ECON 110) (MATH 156))"],
+    );
+    check("MATH 156 or equivalent", expect!["(MATH 156)"]);
+    check(
+        "ECON 109, and MATH 156 or equivalent",
+        expect!["(all (ECON 109) (MATH 156))"],
+    );
+    check(
+        "ECON 281, 282 and 299",
+        expect!["(all (ECON 281) (ECON 282) (ECON 299))"],
+    );
+    check(
+        "one of CMPUT 175 or CMPUT 275",
+        expect!["(any (CMPUT 175) (CMPUT 275))"],
+    );
+    check(
+        "ECON 281, 282 and 299",
+        expect!["(all (ECON 281) (ECON 282) (ECON 299))"],
+    );
+    check(
+        "one of PHYS 124, PHYS 144, or EN PH 131",
+        expect!["(any (PHYS 124) (PHYS 144) (EN PH 131))"],
+    );
+    check(
+        "ECON 281, and MATH 156",
+        expect!["(all (ECON 281) (MATH 156))"],
+    );
+    check(
+        "ACCTG 614 or 610, FIN 501 or 503",
+        expect!["(all (any (ACCTG 614) (ACCTG 610)) (any (FIN 501) (FIN 503)))"],
+    );
+    check("PL SC 345", expect!["(PL SC 345)"]);
+    check(
+        "ECON 281 and ECON 282, and MATH 156",
+        expect!["(all (all (ECON 281) (ECON 282)) (MATH 156))"],
+    );
+
+    check(
+        "ECON 274 or 274, CMPUT 274",
+        expect!["(all (any (ECON 274) (ECON 274)) (CMPUT 274))"],
+    );
+
+    check("ECON 281 or 282", expect!["(any (ECON 281) (ECON 282))"]);
+
+    check("CMPUT 274", expect!["(CMPUT 274)"]);
+    check(
+        "ECON 281 or 282, CMPUT 274",
+        expect!["(all (any (ECON 281) (ECON 282)) (CMPUT 274))"],
+    );
+
+    check(
+        "ECON 281, 282 or 299",
+        expect!["(any (ECON 281) (ECON 282) (ECON 299))"],
+    );
+    check(
+        "ECON 281, 282 and 299, and MATH 156",
+        expect!["(all (all (ECON 281) (ECON 282) (ECON 299)) (MATH 156))"],
+    );
+    check(
+        "ECON 109, ECON 281, 282 and 299, and MATH 156",
+        expect!["(all (ECON 109) (all (ECON 281) (ECON 282) (ECON 299)) (MATH 156))"],
+    );
+
+    check(
+        "one of PHYS 126, PHYS 146, or PHYS 130 and PHYS 208 or 271",
+        expect!["(all (any (PHYS 126) (PHYS 146) (PHYS 130)) (any (PHYS 208) (PHYS 271)))"],
+    );
+    check(
+        "PHYS 130 and PHYS 208 or 271",
+        expect!["(all (PHYS 130) (any (PHYS 208) (PHYS 271)))"],
+    );
+    check(
+        "one of PHYS 124, PHYS 144, or EN PH 131",
+        expect!["(any (PHYS 124) (PHYS 144) (EN PH 131))"],
+    );
+
+    check(
+        "one of PHYS 126, PHYS 146, or PHYS 130 and PHYS 208 or 271",
+        expect!["(all (any (PHYS 126) (PHYS 146) (PHYS 130)) (any (PHYS 208) (PHYS 271)))"],
+    );
+
+    check(
+        "one of PHYS 126, PHYS 146, or PHYS 130 and PHYS 208 or 271",
+        expect!["(all (any (PHYS 126) (PHYS 146) (PHYS 130)) (any (PHYS 208) (PHYS 271)))"],
+    );
+
+    check(
+        "MATH 115, 118, 136, 146 or 156, and one of PHYS 124, PHYS 144, or EN PH 131, and one of \
+         PHYS 126, PHYS 146, or PHYS 130 and PHYS 208 or 271",
+        expect![
+            "(all (all (any (MATH 115) (MATH 118) (MATH 136) (MATH 146) (MATH 156)) (PHYS 124)) \
+             (any (PHYS 144) (EN PH 131)) (all (any (PHYS 126) (PHYS 146) (PHYS 130)) (any (PHYS \
+             208) (PHYS 271))))"
+        ],
+    );
+    check(
+        "MATH 115, 118, 136, 146 or 156, and one of PHYS 124, PHYS 144, or EN PH 131, and one of \
+         PHYS 126, PHYS 146, or PHYS 130 and PHYS 208 or 271",
+        expect![
+            "(all (all (any (MATH 115) (MATH 118) (MATH 136) (MATH 146) (MATH 156)) (PHYS 124)) \
+             (any (PHYS 144) (EN PH 131)) (all (any (PHYS 126) (PHYS 146) (PHYS 130)) (any (PHYS \
+             208) (PHYS 271))))"
+        ],
+    );
+    check(
+        "ECON 109, ECON 281, 282 and 299 or equivalent",
+        expect!["(all (ECON 109) (all (ECON 281) (ECON 282) (ECON 299)))"],
+    );
+    check(
+        "ECON 281, 282 and 299 or equivalent",
+        expect!["(all (ECON 281) (ECON 282) (ECON 299))"],
+    );
+
+    check(
+        "ECON 109, ECON 281, 282 and 299 or equivalent, and MATH 156 or equivalent",
+        expect!["(all (ECON 109) (all (ECON 281) (ECON 282) (ECON 299)) (MATH 156))"],
+    );
+    check(
+        "ECON 281, 282 and 299 or equivalent, and MATH 156 or equivalent",
+        expect!["(all (all (ECON 281) (ECON 282) (ECON 299)) (MATH 156))"],
+    );
+    check("IMIN 200 and consent of instructor", expect!["(IMIN 200)"]);
+    check(
+        "ACCTG 211 or 311 and ACCTG 222 or 322",
+        expect!["(all (any (ACCTG 211) (ACCTG 311)) (any (ACCTG 222) (ACCTG 322)))"],
+    );
+    check("EASIA 323", expect!["(EASIA 323)"]);
+    check(
+        "EASIA 323 or EASIA 325",
+        expect!["(any (EASIA 323) (EASIA 325))"],
+    );
+    check(
+        "EASIA 323, or EASIA 325",
+        expect!["(any (EASIA 323) (EASIA 325))"],
+    );
+    check(
+        "RELIG 240, RELIG 343, EASIA 223, EASIA 323, or EASIA 325",
+        expect!["(any (RELIG 240) (RELIG 343) (EASIA 223) (EASIA 323) (EASIA 325))"],
+    );
+    check(
+        "RELIG 240, RELIG 343, EASIA 223, EASIA 323, and EASIA 325",
+        expect!["(all (RELIG 240) (RELIG 343) (EASIA 223) (EASIA 323) (EASIA 325))"],
+    );
+    check(
+        "RELIG 240, RELIG 343, EASIA 223, EASIA 323, EASIA 325 or consent of Instructor",
+        expect!["(any (RELIG 240) (RELIG 343) (EASIA 223) (EASIA 323) (EASIA 325))"],
+    );
+    check(
+        "RELIG 240, RELIG 343, EASIA 223, EASIA 323, EASIA 325 or consent of Instructor",
+        expect!["(any (RELIG 240) (RELIG 343) (EASIA 223) (EASIA 323) (EASIA 325))"],
+    );
+    check(
+        "one of RELIG 240, RELIG 343, EASIA 223, EASIA 323, EASIA 325 or consent of Instructor",
+        expect!["(any (RELIG 240) (RELIG 343) (EASIA 223) (EASIA 323) (EASIA 325))"],
+    );
+    check(
+        "BIOCH 200, PL SC 345, or consent of instructor",
+        expect!["(any (BIOCH 200) (PL SC 345))"],
+    );
+    check(
+        "One of AUHIS 366, 369, 372, 378",
+        expect!["(any (AUHIS 366) (AUHIS 369) (AUHIS 372) (AUHIS 378))"],
+    );
+    check("ECE 202 or E E 240", expect!["(any (ECE 202) (E E 240))"]);
+    check(
+        "CMPUT 204, one of CMPUT 229, E E 380 or ECE 212 and one of MATH 225, 227, or 228 or \
+         consent of the instructor",
+        expect![
+            "(all (CMPUT 204) (any (CMPUT 229) (E E 380) (ECE 212)) (any (MATH 225) (MATH 227) \
+             (MATH 228)))"
+        ],
+    );
+    check(
+        "MATH 100/114/117/134/144",
+        expect!["(any (MATH 100) (MATH 114) (MATH 117) (MATH 134) (MATH 144))"],
+    );
+    check(
+        "MATH 100/114/117/134/144, PHYS 124/144 or EN PH131",
+        expect![
+            "(any (any (MATH 100) (MATH 114) (MATH 117) (MATH 134) (MATH 144)) (any (PHYS 124) \
+             (PHYS 144)) (EN PH 131))"
+        ],
+    );
+    check(
+        "MATH 100/114/117/134/144, PHYS 124/144 or EN PH 131",
+        expect![
+            "(any (any (MATH 100) (MATH 114) (MATH 117) (MATH 134) (MATH 144)) (any (PHYS 124) \
+             (PHYS 144)) (EN PH 131))"
+        ],
+    );
+}
+
+#[test]
+fn misc_broken() {
+    check(
+        "AUCSC 112, or AUCSC 211 or AUSCI 235",
+        expect![[r#"
+            Error: Error at <str>:[1,27]:
+            	...r AUCSC 211 or -->AUSCI 235...
+            	Expected EnOrAlternativeOption."#]],
+    );
+    check(
+        "CMPUT 174, 274 or consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,18]:
+            	...UT 174, 274 or -->consent of the ...
+            	Expected one of Number, Topic, Alternative, EnOrAlternativeOption."#]],
+    );
+    check(
+        "French 30 ou l'équivalent, ou FRANC 101 ou FREN 100 ou 111/112",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->French 30 ou l'...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "CMPUT 174 or 274, or consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,18]:
+            	...UT 174 or 274, -->or consent of t...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 175 or 275 and CMPUT 272; one of MATH 100, 113, 114, 117, 134, 144, 154, or SCI 100",
+        expect![[r#"
+            Error: Error at <str>:[1,32]:
+            	...and CMPUT 272; -->one of MATH 100...
+            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+    );
+    check(
+        "Any introductory-level Computing Science course, plus knowledge of introductory-level \
+         MATH and STAT; or consent of the instructor or SCI 100",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->Any introductor...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "Any 100-level course",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->Any 100-level c...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "Second-year standing",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->Second-year sta...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "one of STAT 141, 151, 235, or 265, or SCI 151",
+        expect![[r#"
+            Error: Error at <str>:[1,35]:
+            	..., 235, or 265, -->or SCI 151...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 174 or 274; one of MATH 100, 114, 117, 134, 144, or 154",
+        expect![[r#"
+            Error: Error at <str>:[1,61]:
+            	...34, 144, or 154-->...
+            	Expected one of STOP, Comma, Semicolon, AndOr, And, Et, Or, Ou, Unless."#]],
+    );
+    check(
+        "CMPUT 175 or 275; CMPUT 272; MATH 125 or 127; one of STAT 141, 151, 235, or 265, or SCI \
+         151",
+        expect![[r#"
+            Error: Error at <str>:[1,81]:
+            	..., 235, or 265, -->or SCI 151...
+            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 101, 174, 175, 274, or SCI 100",
+        expect![[r#"
+        Error: Error at <str>:[1,29]:
+        	..., 175, 274, or -->SCI 100...
+        	Expected one of Number, Topic, Alternative, EnOrAlternativeOption."#]],
+    );
+    check(
+        "Math 30 or 31",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->Math 30 or 31...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "CMPUT 175 or 274, and 272",
+        expect![[r#"
+            Error: Error at <str>:[1,22]:
+            	...75 or 274, and -->272...
+            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+    );
+    check(
+        "Any introductory-level Computing Science course or SCI 100, and any 200-level course",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->Any introductor...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "CMPUT 204; one of STAT 141, 151, 235 or 265 or SCI 151; one of MATH 225, 227, 228; or \
+         consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,47]:
+            	... 235 or 265 or -->SCI 151; one of...
+            	Expected EnOrAlternativeOption."#]],
+    );
+    check(
+        "one of CMPUT 206, 308, or 411; or consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,31]:
+            	..., 308, or 411; -->or consent of t...
+            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 201, 206, MATH 125 or 127, STAT 151 or 265, or consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,16]:
+            	...MPUT 201, 206, -->MATH 125 or 127...
+            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 340 or 418, or ECE 240",
+        expect![[r#"
+            Error: Error at <str>:[1,18]:
+            	...UT 340 or 418, -->or ECE 240...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 201 and 204 or 275; one of CMPUT 229, E E 380 or ECE 212; and STAT 252 or 266",
+        expect![[r#"
+            Error: Error at <str>:[1,21]:
+            	...201 and 204 or -->275; one of CMP...
+            	Expected EnOrAlternativeOption."#]],
+    );
+    check(
+        "CMPUT 201 and 204 or 275; one of CMPUT 229, E E 380 or ECE 212, and MATH 125",
+        expect![[r#"
+            Error: Error at <str>:[1,21]:
+            	...201 and 204 or -->275; one of CMP...
+            	Expected EnOrAlternativeOption."#]],
+    );
+    check(
+        "CMPUT 115 or 175; one of MATH 100, 113, 114, 117, 134, 144, 154; MATH 125; STAT 141, 151 \
+         or 235",
+        expect![[r#"
+            Error: Error at <str>:[1,95]:
+            	...141, 151 or 235-->...
+            	Expected one of STOP, Comma, Semicolon, AndOr, And, Et, Or, Ou, Unless."#]],
+    );
+    check(
+        "CMPUT 204 or 275; MATH 125, 214; one of STAT 141, 151, 235 or 265 or SCI 151",
+        expect![[r#"
+            Error: Error at <str>:[1,33]:
+            	...MATH 125, 214; -->one of STAT 141...
+            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 201 or 275, and 204",
+        expect![[r#"
+            Error: Error at <str>:[1,22]:
+            	...01 or 275, and -->204...
+            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+    );
+    check(
+        "any 200-level Computing Science course",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->any 200-level C...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "CMPUT 175 or 275; one of CMPUT 267, 466, or STAT 265; or consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,44]:
+            	...T 267, 466, or -->STAT 265; or co...
+            	Expected one of Number, Topic, Alternative, EnOrAlternativeOption."#]],
+    );
+    check(
+        "CMPUT 204 and 267; one of MATH 115, 118, 136, 146, or 156",
+        expect![[r#"
+            Error: Error at <str>:[1,17]:
+            	...PUT 204 and 267-->; one of MATH 1...
+            	Expected one of STOP, Comma, Or, Ou, Unless."#]],
+    );
+    check(
+        "CMPUT 201 and 204, or 275; one of CMPUT 229, E E 380 or ECE 212",
+        expect![[r#"
+            Error: Error at <str>:[1,19]:
+            	...T 201 and 204, -->or 275; one of ...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+    );
+    check(
+        "CMPUT 201 and 204, or 275; and CMPUT 291",
+        expect![[r#"
+            Error: Error at <str>:[1,19]:
+            	...T 201 and 204, -->or 275; and CMP...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+    );
+    check(
+        "One of CMPUT 201 or CMPUT 275, CMPUT 204, and any 300-level Computing Science course, or \
+         consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,46]:
+            	...CMPUT 204, and -->any 300-level C...
+            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+    );
+    check(
+        "CMPUT 301 and 291, or consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,19]:
+            	...T 301 and 291, -->or consent of t...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+    );
+    check(
+        "CMPUT 204 or 275, 301; one of CMPUT 340, 418 or equivalent knowledge, and MATH 214",
+        expect![[r#"
+            Error: Error at <str>:[1,18]:
+            	...UT 204 or 275, -->301; one of CMP...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 201 and 204, or 275; one of CMPUT 340, 418 or equivalent knowledge; MATH 214",
+        expect![[r#"
+            Error: Error at <str>:[1,19]:
+            	...T 201 and 204, -->or 275; one of ...
+            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+    );
+    check(
+        "one of CMPUT 229, E E 380 or ECE 212, and a 300-level Computing Science course or \
+         consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,42]:
+            	...r ECE 212, and -->a 300-level Com...
+            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+    );
+    check(
+        "CMPUT 201 or 275; one of CMPUT 340, 418, ECE 240, or equivalent knowledge; one of MATH \
+         101, 115, 118, 136, 146 or 156, and one of MATH 102, 125, or 127",
+        expect![[r#"
+            Error: Error at <str>:[1,64]:
+            	... or equivalent -->knowledge; one ...
+            	Expected one of STOP, Comma, Semicolon, AndOr, And, Et, Or, Ou, Unless."#]],
+    );
+    check(
+        "CMPUT 201 or 275; one of CMPUT 229, E E 380 or ECE 212",
+        expect![[r#"
+            Error: Error at <str>:[1,54]:
+            	... 380 or ECE 212-->...
+            	Expected one of STOP, Comma, Semicolon, Slash, AndOr, And, Et, Or, Ou, Unless."#]],
+    );
+    check(
+        "any 300-level Computing Science course",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->any 300-level C...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "201 or 275, and any 300-level Computing Science course",
+        expect![[r#"
+            Error: Error at <str>:[1,0]:
+            	...-->201 or 275, and...
+            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+    );
+    check(
+        "one of CMPUT 340 or 418; one of STAT 141, 151, 235 or 265 or SCI 151; or consent of the \
+         instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,61]:
+            	... 235 or 265 or -->SCI 151; or con...
+            	Expected EnOrAlternativeOption."#]],
+    );
+    check(
+        "CMPUT 204 or 275; MATH 125; CMPUT 267 or MATH 214; or consent of the instructor",
+        expect![[r#"
+            Error: Error at <str>:[1,51]:
+            	...7 or MATH 214; -->or consent of t...
+            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+    );
+    check(
+        "CMPUT 204 and CMPUT 267; any 300-level Computing Science course; and one of MATH 101, \
+         115, 118, 136, 146, or 156",
+        expect![[r#"
+            Error: Error at <str>:[1,25]:
+            	...and CMPUT 267; -->any 300-level C...
+            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+    );
+    check(
+        "one of CMPUT 191 or 195, one of CMPUT 200, NS 115, or PHIL 385, and three of CMPUT 267, \
+         CMPUT 291, CMPUT 328, CMPUT 361, CMPUT 367, CMPUT 461, CMPUT 466, BIOIN 301, BIOIN 401, \
+         BIOL 330, BIOL 331, BIOL 332, BIOL 380, BIOL 430, BIOL 471, IMIN 410, MA SC 475, EAS \
+         221, EAS 351, EAS 364, EAS 372, GEOPH 426, GEOPH 431, GEOPH 438, PHYS 234, PHYS 295, \
+         PHYS 420, STAT 441, STAT 471, STAT 479, AREC 313, REN R 201, REN R 426, REN R 480, FIN \
+         440, MARK 312, OM 420, or SEM 330",
+        expect![[r#"
+            Error: Error at <str>:[1,68]:
+            	... PHIL 385, and -->three of CMPUT ...
+            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+    );
+}

--- a/catalogue_scraper/src/requirements_tests.rs
+++ b/catalogue_scraper/src/requirements_tests.rs
@@ -280,7 +280,7 @@ fn misc_working() {
         "CMPUT 204, one of CMPUT 229, E E 380 or ECE 212 and one of MATH 225, 227, or 228 or \
          consent of the instructor",
         expect![
-            "(all (CMPUT 204) (any (CMPUT 229) (E E 380) (ECE 212)) (any (MATH 225) (MATH 227) \
+            "(all (any (CMPUT 204) (CMPUT 229) (E E 380) (ECE 212)) (any (MATH 225) (MATH 227) \
              (MATH 228)))"
         ],
     );
@@ -302,44 +302,90 @@ fn misc_working() {
              (PHYS 144)) (EN PH 131))"
         ],
     );
+    check(
+        "AUCSC 112, or AUCSC 211 or AUSCI 235",
+        expect!["(any (AUCSC 112) (any (AUCSC 211) (AUSCI 235)))"],
+    );
+    check(
+        "CMPUT 174, 274 or consent of the instructor",
+        expect!["(any (CMPUT 174) (CMPUT 274))"],
+    );
+    check(
+        "FIN 201 or 301, and a minimum grade of C- in ACCTG 314 or 414",
+        expect!["(all (any (FIN 201) (FIN 301)) (any (ACCTG 314) (ACCTG 414)))"],
+    );
+    check(
+        "ACCTG 414 or 412; FIN 301",
+        expect!["(all (any (ACCTG 414) (ACCTG 412)) (FIN 301))"],
+    );
+    check(
+        "CMPUT 174 or 274; one of MATH 100, 114, 117, 134, 144, or 154",
+        expect![
+            "(all (any (CMPUT 174) (CMPUT 274)) (any (MATH 100) (MATH 114) (MATH 117) (MATH 134) \
+             (MATH 144) (MATH 154)))"
+        ],
+    );
+    check(
+        "CMPUT 101, 174, 175, 274, or SCI 100",
+        expect!["(any (any (CMPUT 101) (CMPUT 174) (CMPUT 175) (CMPUT 274)) (SCI 100))"],
+    );
+    check(
+        "CMPUT 204 and 267; one of MATH 115, 118, 136, 146, or 156",
+        expect![
+            "(all (all (CMPUT 204) (CMPUT 267)) (any (MATH 115) (MATH 118) (MATH 136) (MATH 146) \
+             (MATH 156)))"
+        ],
+    );
+    check(
+        "CMPUT 204 or 275; MATH 125; CMPUT 267 or MATH 214; or consent of the instructor",
+        expect![
+            "(all (any (CMPUT 204) (CMPUT 275)) (any (MATH 125) (any (CMPUT 267) (MATH 214))))"
+        ],
+    );
+
+    check(
+        "CMPUT 115 or 175; one of MATH 100, 113, 114, 117, 134, 144, 154; MATH 125; STAT 141, 151 \
+         or 235",
+        expect![
+            "(all (any (CMPUT 115) (CMPUT 175)) (any (MATH 100) (MATH 113) (MATH 114) (MATH 117) \
+             (MATH 134) (MATH 144) (MATH 154)) (MATH 125) (any (STAT 141) (STAT 151) (STAT 235)))"
+        ],
+    );
+    check(
+        "CMPUT 175 or 275 and CMPUT 272; one of MATH 100, 113, 114, 117, 134, 144, 154, or SCI 100",
+        expect![
+            "(all (any (CMPUT 175) (CMPUT 275)) (any (CMPUT 272) (any (MATH 100) (MATH 113) (MATH \
+             114) (MATH 117) (MATH 134) (MATH 144) (MATH 154)) (SCI 100)))"
+        ],
+    );
+    check(
+        "CMPUT 201 or 275; one of CMPUT 229, E E 380 or ECE 212",
+        expect!["(all (any (CMPUT 201) (CMPUT 275)) (any (CMPUT 229) (E E 380) (ECE 212)))"],
+    );
 }
 
 #[test]
 fn misc_broken() {
     check(
-        "AUCSC 112, or AUCSC 211 or AUSCI 235",
+        "AUCSC 120, AUMAT 110 or 111 or 116, and AUMAT 120",
         expect![[r#"
-            Error: Error at <str>:[1,27]:
-            	...r AUCSC 211 or -->AUSCI 235...
+            Error: Error at <str>:[1,31]:
+            	... 110 or 111 or -->116, and AUMAT ...
             	Expected EnOrAlternativeOption."#]],
-    );
-    check(
-        "CMPUT 174, 274 or consent of the instructor",
-        expect![[r#"
-            Error: Error at <str>:[1,18]:
-            	...UT 174, 274 or -->consent of the ...
-            	Expected one of Number, Topic, Alternative, EnOrAlternativeOption."#]],
     );
     check(
         "French 30 ou l'équivalent, ou FRANC 101 ou FREN 100 ou 111/112",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->French 30 ou l'...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "CMPUT 174 or 274, or consent of the instructor",
         expect![[r#"
             Error: Error at <str>:[1,18]:
             	...UT 174 or 274, -->or consent of t...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
-    );
-    check(
-        "CMPUT 175 or 275 and CMPUT 272; one of MATH 100, 113, 114, 117, 134, 144, 154, or SCI 100",
-        expect![[r#"
-            Error: Error at <str>:[1,32]:
-            	...and CMPUT 272; -->one of MATH 100...
-            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "Any introductory-level Computing Science course, plus knowledge of introductory-level \
@@ -347,35 +393,28 @@ fn misc_broken() {
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->Any introductor...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "Any 100-level course",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->Any 100-level c...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "Second-year standing",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->Second-year sta...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "one of STAT 141, 151, 235, or 265, or SCI 151",
         expect![[r#"
             Error: Error at <str>:[1,35]:
             	..., 235, or 265, -->or SCI 151...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
-    );
-    check(
-        "CMPUT 174 or 274; one of MATH 100, 114, 117, 134, 144, or 154",
-        expect![[r#"
-            Error: Error at <str>:[1,61]:
-            	...34, 144, or 154-->...
-            	Expected one of STOP, Comma, Semicolon, AndOr, And, Et, Or, Ou, Unless."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "CMPUT 175 or 275; CMPUT 272; MATH 125 or 127; one of STAT 141, 151, 235, or 265, or SCI \
@@ -383,35 +422,28 @@ fn misc_broken() {
         expect![[r#"
             Error: Error at <str>:[1,81]:
             	..., 235, or 265, -->or SCI 151...
-            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
-    );
-    check(
-        "CMPUT 101, 174, 175, 274, or SCI 100",
-        expect![[r#"
-        Error: Error at <str>:[1,29]:
-        	..., 175, 274, or -->SCI 100...
-        	Expected one of Number, Topic, Alternative, EnOrAlternativeOption."#]],
+            	Expected one of Number, Topic, OneOf, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Or, Ou."#]],
     );
     check(
         "Math 30 or 31",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->Math 30 or 31...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "CMPUT 175 or 274, and 272",
         expect![[r#"
             Error: Error at <str>:[1,22]:
             	...75 or 274, and -->272...
-            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+            	Expected one of Number, Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative."#]],
     );
     check(
         "Any introductory-level Computing Science course or SCI 100, and any 200-level course",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->Any introductor...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "CMPUT 204; one of STAT 141, 151, 235 or 265 or SCI 151; one of MATH 225, 227, 228; or \
@@ -426,21 +458,21 @@ fn misc_broken() {
         expect![[r#"
             Error: Error at <str>:[1,31]:
             	..., 308, or 411; -->or consent of t...
-            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "CMPUT 201, 206, MATH 125 or 127, STAT 151 or 265, or consent of the instructor",
         expect![[r#"
-            Error: Error at <str>:[1,16]:
-            	...MPUT 201, 206, -->MATH 125 or 127...
-            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+            Error: Error at <str>:[1,50]:
+            	...AT 151 or 265, -->or consent of t...
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "CMPUT 340 or 418, or ECE 240",
         expect![[r#"
             Error: Error at <str>:[1,18]:
             	...UT 340 or 418, -->or ECE 240...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "CMPUT 201 and 204 or 275; one of CMPUT 229, E E 380 or ECE 212; and STAT 252 or 266",
@@ -457,61 +489,46 @@ fn misc_broken() {
             	Expected EnOrAlternativeOption."#]],
     );
     check(
-        "CMPUT 115 or 175; one of MATH 100, 113, 114, 117, 134, 144, 154; MATH 125; STAT 141, 151 \
-         or 235",
-        expect![[r#"
-            Error: Error at <str>:[1,95]:
-            	...141, 151 or 235-->...
-            	Expected one of STOP, Comma, Semicolon, AndOr, And, Et, Or, Ou, Unless."#]],
-    );
-    check(
         "CMPUT 204 or 275; MATH 125, 214; one of STAT 141, 151, 235 or 265 or SCI 151",
         expect![[r#"
-            Error: Error at <str>:[1,33]:
-            	...MATH 125, 214; -->one of STAT 141...
-            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+            Error: Error at <str>:[1,69]:
+            	... 235 or 265 or -->SCI 151...
+            	Expected EnOrAlternativeOption."#]],
     );
     check(
         "CMPUT 201 or 275, and 204",
         expect![[r#"
             Error: Error at <str>:[1,22]:
             	...01 or 275, and -->204...
-            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+            	Expected one of Number, Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative."#]],
     );
     check(
         "any 200-level Computing Science course",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->any 200-level C...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "CMPUT 175 or 275; one of CMPUT 267, 466, or STAT 265; or consent of the instructor",
         expect![[r#"
-            Error: Error at <str>:[1,44]:
-            	...T 267, 466, or -->STAT 265; or co...
-            	Expected one of Number, Topic, Alternative, EnOrAlternativeOption."#]],
-    );
-    check(
-        "CMPUT 204 and 267; one of MATH 115, 118, 136, 146, or 156",
-        expect![[r#"
-            Error: Error at <str>:[1,17]:
-            	...PUT 204 and 267-->; one of MATH 1...
-            	Expected one of STOP, Comma, Or, Ou, Unless."#]],
+            Error: Error at <str>:[1,54]:
+            	..., or STAT 265; -->or consent of t...
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "CMPUT 201 and 204, or 275; one of CMPUT 229, E E 380 or ECE 212",
         expect![[r#"
             Error: Error at <str>:[1,19]:
             	...T 201 and 204, -->or 275; one of ...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et."#]],
     );
     check(
         "CMPUT 201 and 204, or 275; and CMPUT 291",
         expect![[r#"
             Error: Error at <str>:[1,19]:
             	...T 201 and 204, -->or 275; and CMP...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et."#]],
     );
     check(
         "One of CMPUT 201 or CMPUT 275, CMPUT 204, and any 300-level Computing Science course, or \
@@ -519,28 +536,28 @@ fn misc_broken() {
         expect![[r#"
             Error: Error at <str>:[1,46]:
             	...CMPUT 204, and -->any 300-level C...
-            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+            	Expected one of Number, Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative."#]],
     );
     check(
         "CMPUT 301 and 291, or consent of the instructor",
         expect![[r#"
             Error: Error at <str>:[1,19]:
             	...T 301 and 291, -->or consent of t...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et."#]],
     );
     check(
         "CMPUT 204 or 275, 301; one of CMPUT 340, 418 or equivalent knowledge, and MATH 214",
         expect![[r#"
             Error: Error at <str>:[1,18]:
             	...UT 204 or 275, -->301; one of CMP...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "CMPUT 201 and 204, or 275; one of CMPUT 340, 418 or equivalent knowledge; MATH 214",
         expect![[r#"
             Error: Error at <str>:[1,19]:
             	...T 201 and 204, -->or 275; one of ...
-            	Expected one of Topic, OneOf, Both, Alternative, AndOr, And, Et."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et."#]],
     );
     check(
         "one of CMPUT 229, E E 380 or ECE 212, and a 300-level Computing Science course or \
@@ -548,7 +565,7 @@ fn misc_broken() {
         expect![[r#"
             Error: Error at <str>:[1,42]:
             	...r ECE 212, and -->a 300-level Com...
-            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+            	Expected one of Number, Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative."#]],
     );
     check(
         "CMPUT 201 or 275; one of CMPUT 340, 418, ECE 240, or equivalent knowledge; one of MATH \
@@ -559,25 +576,18 @@ fn misc_broken() {
             	Expected one of STOP, Comma, Semicolon, AndOr, And, Et, Or, Ou, Unless."#]],
     );
     check(
-        "CMPUT 201 or 275; one of CMPUT 229, E E 380 or ECE 212",
-        expect![[r#"
-            Error: Error at <str>:[1,54]:
-            	... 380 or ECE 212-->...
-            	Expected one of STOP, Comma, Semicolon, Slash, AndOr, And, Et, Or, Ou, Unless."#]],
-    );
-    check(
         "any 300-level Computing Science course",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->any 300-level C...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "201 or 275, and any 300-level Computing Science course",
         expect![[r#"
             Error: Error at <str>:[1,0]:
             	...-->201 or 275, and...
-            	Expected one of Topic, OneOf, Both, Alternative, None."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, None."#]],
     );
     check(
         "one of CMPUT 340 or 418; one of STAT 141, 151, 235 or 265 or SCI 151; or consent of the \
@@ -588,19 +598,12 @@ fn misc_broken() {
             	Expected EnOrAlternativeOption."#]],
     );
     check(
-        "CMPUT 204 or 275; MATH 125; CMPUT 267 or MATH 214; or consent of the instructor",
-        expect![[r#"
-            Error: Error at <str>:[1,51]:
-            	...7 or MATH 214; -->or consent of t...
-            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
-    );
-    check(
         "CMPUT 204 and CMPUT 267; any 300-level Computing Science course; and one of MATH 101, \
          115, 118, 136, 146, or 156",
         expect![[r#"
             Error: Error at <str>:[1,25]:
             	...and CMPUT 267; -->any 300-level C...
-            	Expected one of Number, Topic, OneOf, Alternative, AndOr, And, Et, Or, Ou."#]],
+            	Expected one of Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative, AndOr, And, Et, Number, Or, Ou."#]],
     );
     check(
         "one of CMPUT 191 or 195, one of CMPUT 200, NS 115, or PHIL 385, and three of CMPUT 267, \
@@ -612,6 +615,6 @@ fn misc_broken() {
         expect![[r#"
             Error: Error at <str>:[1,68]:
             	... PHIL 385, and -->three of CMPUT ...
-            	Expected one of Number, Topic, OneOf, Both, Alternative."#]],
+            	Expected one of Number, Topic, OneOf, Both, Either, AMinimumGradeIn, Alternative."#]],
     );
 }


### PR DESCRIPTION
Doesn't work every time, but when it does you now get JSON like this from the scraper output:

```json
{
  "meta": {
    "faculty": "Faculty of Science",
    "subject": "CMPUT",
    "catalog": "175",
    "course": "CMPUT 175",
    "coursetitle": "Introduction to the Foundations of Computation II",
    "credits": "3.00",
    "career": "UGRD",
    "term": "Winter Term 2024,Spring Term 2024",
    "sections": "34",
    "sections_online": "0"
  },
  "desc": "A continuation of CMPUT 174, revisiting topics of greater depth and complexity. More sophisticated notions such as objects, functional programming, and Abstract Data Types are explored. Various algorithms, including popular searching and sorting algorithms, are studied and compared in terms of time and space efficiency. Upon completion of this two course sequence, students from any discipline should be able to build programs to solve basic problems in their area, and will be prepared to take more advanced Computing Science courses. Prerequisite: CMPUT 174 or SCI 100. Credit cannot be obtained for CMPUT 175 if one already has credit for CMPUT 275, except with permission of the Department.",
  "prereqs": {
    "any": [
      {
        "course": {
          "topic": "CMPUT",
          "number": "174"
        }
      },
      {
        "course": {
          "topic": "SCI",
          "number": "100"
        }
      }
    ]
  },
  "coreqs": {}
}
```